### PR TITLE
Adding libgfortran

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install http://repo.grid.iu.edu/osg/3.3/osg-3.3-el6-release-latest.rp
     yum -y install osg-wn-client \
                    osg-wn-client-glexec \
                    redhat-lsb-core 
+    yum -y install libgfortran
 
 # Install Singularity
 RUN yum -y install --enablerepo osg-upcoming-development singularity && \


### PR DESCRIPTION
CMS uses Brian's [image](https://github.com/bbockelm/docker-cms/blob/master/Dockerfile#L1), which uses this image and libgfrotran is needed. It is installed in the OSG basic [singularity image](https://github.com/opensciencegrid/osgvo-el6/blob/master/Dockerfile)

But not this one. @djw8605 can you merge it please?